### PR TITLE
Handle array type

### DIFF
--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -91,6 +91,7 @@ export type LlmToolParameterOpenAI = {
   type: string
   enum?: string[]
   required?: boolean
+  items?: any
 }
 
 export type LlmToolOpenAI = {


### PR DESCRIPTION
Tools with `type` as `array` requires a `items` fields with the inner type definition. 

This PR address the problem but lacks of tests and I am not generally sure it is properly addressing all the supported provider.

