### PR TITLE
Fix/typo serialize, export Plugin as a default and fix some Thinking in Claude (needs temperature = 1) 

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5,7 +5,7 @@ import { LlmResponse, LlmCompletionOpts, LLmCompletionPayload, LlmChunk, LlmTool
 import { PluginParameter } from 'types/plugin'
 import { minimatch } from 'minimatch'
 import Message from './models/message'
-import Plugin from './plugin'
+import { Plugin } from './plugin'
 
 export type LlmStreamingContextBase = {
   model: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
-
 export * from './types/index'
 export * from './types/plugin'
 export * from './types/llm'
 
 import Attachment, { textFormats, imageFormats, extensionToMimeType, mimeTypeToExtension } from './models/attachment'
 import Message from './models/message'
-import Plugin from './plugin'
+import { Plugin } from './plugin'
 
 import LlmEngine from './engine'
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,10 +1,13 @@
-
 import { PluginParameter } from 'types/plugin'
 
-export default class Plugin {
+export class Plugin {
+
+  serializeInTools(): boolean {
+    return true
+  }
 
   sezializeInTools(): boolean {
-    return true
+    return this.serializeInTools()
   }
 
   isEnabled(): boolean {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -59,3 +59,5 @@ export class Plugin {
   }
 
 }
+
+export default Plugin;

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,9 +1,8 @@
-
 import { EngineCreateOpts, Model } from 'types/index'
 import { LlmChunk, LlmCompletionOpts, LlmResponse, LlmStream, LlmToolCall, LLmCompletionPayload, LlmStreamingResponse } from 'types/llm'
 import Message from '../models/message'
 import LlmEngine, { LlmStreamingContextBase } from '../engine'
-import Plugin from '../plugin'
+import { Plugin } from '../plugin'
 import logger from '../logger'
 
 import Anthropic from '@anthropic-ai/sdk'

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -281,12 +281,14 @@ export default class extends LlmEngine {
   }
 
   getCompletionOpts(model: string, opts?: LlmCompletionOpts): Omit<MessageCreateParamsBase, 'model'|'messages'|'stream'|'tools'|'tool_choice'> {
+    const isThinkingEnabled = this.modelIsReasoning(model) && opts?.reasoning;
+    
     return {
       max_tokens: opts?.maxTokens ?? this.getMaxTokens(model),
-      ...(opts?.temperature ? { temperature: opts?.temperature } : {} ),
+      ...(isThinkingEnabled ? { temperature: 1.0 } : (opts?.temperature ? { temperature: opts?.temperature } : {})),
       ...(opts?.top_k ? { top_k: opts?.top_k } : {} ),
       ...(opts?.top_p ? { top_p: opts?.top_p } : {} ),
-      ...(this.modelIsReasoning(model) && opts?.reasoning ? {
+      ...(isThinkingEnabled ? {
         thinking: {
           type: 'enabled',
           budget_tokens: opts.reasoningBudget || (opts?.maxTokens || this.getMaxTokens(model)) / 2,

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -63,7 +63,10 @@ export default class extends LlmEngine {
   }
 
   modelIsReasoning(model: string): boolean {
-    return model.startsWith('claude-3-7-sonnet')
+    // Support both the specific test model and any Claude 3.7 model
+    return model === 'claude-3-7-sonnet-thinking' || 
+           model.includes('claude-3-7') ||
+           model.includes('claude-3.7');
   }
 
   async getModels(): Promise<Model[]> {
@@ -254,7 +257,6 @@ export default class extends LlmEngine {
   }
 
   async doStreamNormal(context: AnthropicStreamingContext): Promise<LlmStream> {
-
     logger.log(`[anthropic] prompting model ${context.model}`)
     return this.client.messages.create({
       model: context.model,
@@ -264,7 +266,6 @@ export default class extends LlmEngine {
       ...await this.getToolOpts(context.model, context.opts),
       stream: true,
     })
-
   }
 
   async doStreamBeta(context: AnthropicStreamingContext): Promise<LlmStream> {

--- a/tests/unit/engine_anthropic.test.ts
+++ b/tests/unit/engine_anthropic.test.ts
@@ -1,4 +1,3 @@
-
 import { vi, beforeEach, expect, test } from 'vitest'
 import { Plugin1, Plugin2, Plugin3 } from '../mocks/plugins'
 import Message from '../../src/models/message'
@@ -265,7 +264,7 @@ test('Anthropic thinking', async () => {
     new Message('system', 'instruction'),
     new Message('user', 'prompt'),
   ], { reasoning: true })
-  expect(_Anthropic.default.prototype.messages.create).toHaveBeenCalledWith({
+  expect(_Anthropic.default.prototype.messages.create).toHaveBeenNthCalledWith(1, {
     model: 'model',
     system: 'instruction',
     messages: [ { role: 'user', content: 'prompt' }, ],
@@ -276,7 +275,7 @@ test('Anthropic thinking', async () => {
     new Message('system', 'instruction'),
     new Message('user', 'prompt'),
   ], { reasoning: true })
-  expect(_Anthropic.default.prototype.messages.create).toHaveBeenCalledWith({
+  expect(_Anthropic.default.prototype.messages.create).toHaveBeenNthCalledWith(2, {
     model: 'claude-3-7-sonnet-thinking',
     system: 'instruction',
     messages: [ { role: 'user', content: 'prompt' }, ],
@@ -285,6 +284,7 @@ test('Anthropic thinking', async () => {
       type: 'enabled',
       budget_tokens: 2048,
     },
+    temperature: 1,
     stream: true,
   })
 })


### PR DESCRIPTION
This PR fixes a spelling error (serialize), exports Plugin and fixes temperature = 1 for claude. I made the isReasoning a bit more fuzzy for claude to make different permuatations of the same model say yes.