### PR TITLE
fix: passing customOpts to ollama

### DIFF
--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -337,6 +337,9 @@ export default class extends LlmEngine {
     if (opts?.structuredOutput) {
       chatOptions.format = zodToJsonSchema(opts.structuredOutput.structure, { name: opts.structuredOutput.name })
     }
+    if (opts?.customOpts) {
+      chatOptions.options = { ...chatOptions.options, ...opts.customOpts }
+    }
     if (Object.keys(opts || {}).length === 0) {
       delete chatOptions.options
     }


### PR DESCRIPTION
As I was trying to use this library with ollama I hit a wall while trying to configure the model. I realized that `opts.customOpts` was not passed to the ollama API, which made it impossible to configure thinking/reasoning modes amongst many other things. 

~~In this fix values in `opts` take precedence over `opts.customOpts` if there is a collision.
Should this be handled differently? Where should this behavior be documented?~~

Edit: since then I went back and realized the precendence is the other way around in the openai provider (the single provider that passes `customOpts` on.)

I hope this omission wasn't intentional on your part and I'm not wasting your time. :D 
Thanks for the consideration!