### PR TITLE
fix: model variant wildcard for ollama reasoning models

### DIFF
--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -116,15 +116,15 @@ export default class extends LlmEngine {
 
     const reasoningModels = [
       'cogito:*',
-      'deepseek-r1',
-      'deepseek-v3.1',
-      'gpt-oss',
-      'gpt-oss-safeguard',
-      'magistral',
+      'deepseek-r1:*',
+      'deepseek-v3.1:*',
+      'gpt-oss:*',
+      'gpt-oss-safeguard:*',
+      'magistral:*',
       'openthinker:*',
       'phi:*',
       'qwq:*',
-      'qwen3',
+      'qwen3:*',
     ]
 
     return {


### PR DESCRIPTION
While working with ollama I was surprised that some models that should be capable of reasoning/thinking were reported without the capability by this library.  After looking into the code I realized that in a [previous commit](https://github.com/nbonamy/multi-llm-ts/commit/593973c85d184b9cb89226486935a66ce06eb156) there were some models added without the `:*` glob pattern, yet  `minimatch` was used to match their names.

In this fix I added the glob pattern, although strictly speaking a simpler predicate could be used just like in the previous lines.

Thanks for the consideration!