### PR TITLE
Support both `reasoning` and `reasoning_content`

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -548,15 +548,18 @@ export default class extends LlmEngine {
       context.done = true
     }
 
-    // @ts-expect-error reasoning content for some providers
-    if (chunk.choices?.length && chunk.choices?.[0]?.delta?.reasoning_content) {
-      // @ts-expect-error reasoning content for some providers
-      context.reasoningContent += chunk.choices?.[0]?.delta?.reasoning_content
-      yield {
-        type: 'reasoning',
-        // @ts-expect-error reasoning content for some providers
-        text: chunk.choices?.[0]?.delta?.reasoning_content || '',
-        done: done,
+    // @ts-expect-error reasoning content for some providers (supports both reasoning_content and reasoning)
+    if (chunk.choices?.length) {
+      const reasoningText = chunk.choices[0]?.delta?.reasoning_content ||
+        chunk.choices[0]?.delta?.reasoning
+
+      if (reasoningText) {
+        context.reasoningContent += reasoningText
+        yield {
+          type: 'reasoning',
+          text: reasoningText,
+          done: done,
+        }
       }
     }
 


### PR DESCRIPTION
In recent versions, [vLLM renamed `reasoning_content` to `reasoning`](https://github.com/vllm-project/vllm/issues/27755). This had downstream effects on Witsy where the reasoning text would not render when using vLLM as the backend.

This PR adds support for both versions for the OpenAI provider.