### PR TITLE
OpenAI provider: improve Responses API integration, forward request options, and vision model selection

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -132,7 +132,7 @@ export default abstract class LlmEngine {
   }
 
   async complete(model: ChatModel|string, thread: Message[], opts?: LlmCompletionOpts): Promise<LlmResponse> {
-    const chatModel = this.toModel(model)
+    const chatModel = this.selectModel(this.toModel(model), thread, opts)
     const messages = this.buildPayload(chatModel, thread, opts)
     return await this.chat(chatModel, messages, opts)
   }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,6 +1,6 @@
 import { minimatch } from 'minimatch'
 import OpenAI, { ClientOptions } from 'openai'
-import { zodResponseFormat } from 'openai/helpers/zod'
+import { zodResponseFormat, zodTextFormat } from 'openai/helpers/zod'
 import { CompletionUsage } from 'openai/resources'
 import { ChatCompletionChunk, ChatCompletionCreateParamsBase, ChatCompletionMessageFunctionToolCall, ChatCompletionMessageParam } from 'openai/resources/chat/completions'
 import { Response, ResponseCreateParams, ResponseFunctionToolCall, ResponseInputItem, ResponseOutputMessage, ResponseStreamEvent, ResponseUsage, Tool, ToolChoiceFunction, ToolChoiceOptions } from 'openai/resources/responses/responses'
@@ -343,6 +343,10 @@ export default class extends LlmEngine {
 
   async stream(model: ChatModel, thread: Message[], opts?: LlmCompletionOpts): Promise<LlmStreamingResponse<OpenAIStreamingContext>> {
 
+    // Select the model before choosing an API, so Responses requests receive the
+    // same vision fallback behavior as Chat Completions requests.
+    model = this.selectModel(model, thread, opts)
+
     // process with responses api?
     if (this.shouldUseResponsesApi(model, opts)) {
       return this.responsesStream(model, thread, opts)
@@ -351,8 +355,6 @@ export default class extends LlmEngine {
     // set baseURL on client
     this.setBaseURL()
 
-    // model: switch to vision if needed
-    model = this.selectModel(model, thread, opts)
     const context: OpenAIStreamingContext = {
       model: model,
       responsesApi: false,
@@ -425,6 +427,7 @@ export default class extends LlmEngine {
   getRequestOptions(model: ChatModel, opts?: LlmCompletionOpts): RequestOptions {
     return {
       ...(opts?.timeout ? { timeout: opts?.timeout } : {}),
+      ...(opts?.abortSignal ? { signal: opts.abortSignal } : {}),
     }
   }
 
@@ -650,10 +653,12 @@ export default class extends LlmEngine {
     logger.debug('[responses] REQUEST', JSON.stringify(request, null, 2))
 
     // call
-    let response: Response = await this.client.responses.create(request) as Response
+    let response: Response = await this.createResponse(request, model, opts) as Response
 
     // we can loop several times calling tools
     while (true) {
+
+      this.assertResponseSucceeded(response)
 
       // update responseId tracking
       logger.debug('[responses] RESPONSE', response)
@@ -664,14 +669,7 @@ export default class extends LlmEngine {
       }
 
       // concatenate text from the output array
-      const messages = response.output.filter((o: any) => o.type === 'message') as ResponseOutputMessage[]
-      for (const message of messages) {
-        for (const content of message.content) {
-          if (content.type === 'output_text') {
-            text += content.text || ''
-          }
-        }
-      }
+      text += this.getResponsesText(response)
       
       // check if we have tool calls
       const toolCalls = response.output?.filter((o: any) => o.type === 'function_call') as ResponseFunctionToolCall[]
@@ -748,6 +746,7 @@ export default class extends LlmEngine {
 
         // build follow-up request
         const followUpReq: ResponseCreateParams = {
+          ...this.getResponsesCompletionOpts(model, opts),
           model: model.id,
           previous_response_id: response.id,
           input: followReqInput,
@@ -759,7 +758,7 @@ export default class extends LlmEngine {
         logger.debug('[responses] FOLLOW-UP REQUEST', JSON.stringify(followUpReq, null, 2))
 
         // continue
-        response = await this.client.responses.create(followUpReq)
+        response = await this.createResponse(followUpReq, model, opts) as Response
         continue
       }
 
@@ -780,7 +779,7 @@ export default class extends LlmEngine {
     logger.log(`[${this.getName()}] prompting model ${model.id}`)
 
     const request = await this.buildResponsesRequestFromMessages(model, thread, opts, true)
-    const stream = await this.client.responses.create(request) as AsyncIterable<ResponseStreamEvent>
+    const stream = await this.createResponse(request, model, opts) as AsyncIterable<ResponseStreamEvent>
     logger.debug('[responsesStream] subscribed')
 
     const context: OpenAIStreamingContext = {
@@ -1060,6 +1059,14 @@ export default class extends LlmEngine {
               break
             }
 
+            case 'error':
+              throw new Error(`[openai] Responses API error${ev.code ? ` (${ev.code})` : ''}: ${ev.message}`)
+
+            case 'response.failed':
+            case 'response.incomplete':
+              this.assertResponseSucceeded(ev.response)
+              break
+
             case 'response.output_item.added':
               switch (ev.item.type) {
                 
@@ -1117,6 +1124,18 @@ export default class extends LlmEngine {
               if (ev.delta) {
                 yield {
                   type: thinking ? 'reasoning' : 'content',
+                  text: ev.delta,
+                  done: false
+                }
+              }
+              break
+            }
+
+            case 'response.reasoning_summary_text.delta':
+            case 'response.reasoning_text.delta': {
+              if (ev.delta) {
+                yield {
+                  type: 'reasoning',
                   text: ev.delta,
                   done: false
                 }
@@ -1211,6 +1230,7 @@ export default class extends LlmEngine {
 
         // now we can build the follow-up request
         const followReq: ResponseCreateParams = {
+          ...this.getResponsesCompletionOpts(model, opts),
           model: model.id,
           previous_response_id: responseId,
           input: followReqInput,
@@ -1222,7 +1242,7 @@ export default class extends LlmEngine {
         logger.debug('[responsesStream] FOLLOW-UP STREAM REQ', JSON.stringify(followReq, null, 2))
 
         // switch stream
-        currentStream = await this.client.responses.create(followReq) as AsyncIterable<ResponseStreamEvent>
+        currentStream = await this.createResponse(followReq, model, opts) as AsyncIterable<ResponseStreamEvent>
 
       }
 
@@ -1376,12 +1396,10 @@ export default class extends LlmEngine {
     }
 
     const req: ResponseCreateParams = {
+      ...this.getResponsesCompletionOpts(model, opts),
       model: model.id,
       ...(instructions ? { instructions } : {}),
       ...(opts?.responseId ? { previous_response_id: opts.responseId } : {}),
-      ...(this.modelSupportsReasoningEffort(model) && opts?.reasoningEffort
-        ? { reasoning: { effort: opts.reasoningEffort } }
-        : {}),
       input,
       stream,
     // The installed OpenAI SDK type may lag the Responses API's supported
@@ -1392,6 +1410,42 @@ export default class extends LlmEngine {
 
     // done
     return req
+  }
+
+  private getResponsesCompletionOpts(model: ChatModel, opts?: LlmCompletionOpts): Partial<ResponseCreateParams> {
+    const text = {
+      ...(this.modelSupportsStructuredOutput(model) && opts?.structuredOutput ? {
+        format: zodTextFormat(opts.structuredOutput.structure, opts.structuredOutput.name),
+      } : {}),
+      ...(this.modelSupportsVerbosity(model) && opts?.verbosity ? { verbosity: opts.verbosity } : {}),
+    }
+
+    return {
+      ...(this.modelSupportsMaxTokens(model) && opts?.maxTokens !== undefined ? { max_output_tokens: opts.maxTokens } : {}),
+      ...(this.modelSupportsTemperature(model) && opts?.temperature !== undefined ? { temperature: opts.temperature } : {}),
+      ...(this.modelSupportsTopP(model) && opts?.top_p !== undefined ? { top_p: opts.top_p } : {}),
+      ...(this.modelSupportsReasoningEffort(model) && opts?.reasoningEffort ? { reasoning: { effort: opts.reasoningEffort } } : {}),
+      ...(Object.keys(text).length ? { text } : {}),
+      ...(this.supportsServiceTiering() && opts?.serviceTier ? { service_tier: opts.serviceTier } : {}),
+      ...(opts?.customOpts || {}),
+    } as Partial<ResponseCreateParams>
+  }
+
+  private createResponse(request: ResponseCreateParams, model: ChatModel, opts?: LlmCompletionOpts): Promise<unknown> {
+    const requestOptions = this.getRequestOptions(model, opts)
+    return Object.keys(requestOptions).length
+      ? this.client.responses.create(request, requestOptions)
+      : this.client.responses.create(request)
+  }
+
+  private assertResponseSucceeded(response: Response): void {
+    if (response.status === 'failed') {
+      const detail = response.error
+      throw new Error(`[openai] Responses API failed${detail?.code ? ` (${detail.code})` : ''}: ${detail?.message || 'Unknown error'}`)
+    }
+    if (response.status === 'incomplete') {
+      throw new Error(`[openai] Responses API response incomplete: ${response.incomplete_details?.reason || 'unknown reason'}`)
+    }
   }
 
   private async attachResponsesTools(req: ResponseCreateParams, model: ChatModel, opts?: LlmCompletionOpts): Promise<void> {
@@ -1639,20 +1693,28 @@ export default class extends LlmEngine {
   }
 
   async continueResponse(model: ChatModel, previousId: string, input: string, opts?: LlmCompletionOpts): Promise<LlmResponse> {
-    const req: any = {
+    const req: ResponseCreateParams = {
+      ...this.getResponsesCompletionOpts(model, opts),
       model: model.id,
       input: [{ type: 'message', role: 'user', content: input }],
       previous_response_id: previousId,
       stream: false,
     }
-    const toolOpts = await this.getToolsOpts(model, opts)
-    if ((toolOpts as any).tools) req.tools = (toolOpts as any).tools
+    await this.attachResponsesTools(req, model, opts)
 
-    const resp: any = await (this.client as any).responses.create(req)
+    const resp = await this.createResponse(req, model, opts) as Response
+    this.assertResponseSucceeded(resp)
+
+    const usage = zeroUsage()
+    if (opts?.usage && resp.usage) {
+      this.accumulateResponsesUsage(usage, resp.usage)
+    }
     return {
       type: 'text',
-      content: (resp.output?.text) ?? '',
-      ...(opts?.usage && resp.usage ? { usage: resp.usage } : {}),
+      content: this.getResponsesText(resp),
+      toolCalls: [],
+      openAIResponseId: resp.id,
+      ...(opts?.usage ? { usage } : {}),
     }
   }
 
@@ -1661,11 +1723,23 @@ export default class extends LlmEngine {
     return await this.continueResponse(model, previousId, input, opts)
   }
 
+  private getResponsesText(response: Response): string {
+    if (response.output_text) {
+      return response.output_text
+    }
+
+    const messages = response.output?.filter((item): item is ResponseOutputMessage => item.type === 'message') || []
+    return messages.flatMap(message => message.content)
+      .filter(content => content.type === 'output_text')
+      .map(content => content.text || '')
+      .join('')
+  }
+
   private accumulateResponsesUsage(cumulate: LlmUsage, usage: ResponseUsage) {
     cumulate.prompt_tokens += usage.input_tokens
     cumulate.completion_tokens += usage.output_tokens
-    cumulate.prompt_tokens_details!.cached_tokens! += usage.input_tokens_details.cached_tokens
-    cumulate.completion_tokens_details!.reasoning_tokens! += usage.output_tokens_details.reasoning_tokens
+    cumulate.prompt_tokens_details!.cached_tokens! += usage.input_tokens_details?.cached_tokens || 0
+    cumulate.completion_tokens_details!.reasoning_tokens! += usage.output_tokens_details?.reasoning_tokens || 0
   }
 
 }

--- a/tests/unit/engine.test.ts
+++ b/tests/unit/engine.test.ts
@@ -287,6 +287,30 @@ test('Switch to vision when model provided', async () => {
   }, {})
 })
 
+test('Complete switches to vision when model provided', async () => {
+  const openai = new OpenAI(config)
+  const messages = [
+    new Message('system', 'instructions'),
+    new Message('user', 'prompt1'),
+  ]
+  messages[1].attach(new Attachment('image', 'image/png'))
+
+  await openai.complete(openai.buildModel('model-no-tool'), messages, {
+    visionFallbackModel: openai.buildModel('model-vision'),
+  })
+
+  expect(_openai.default.prototype.chat.completions.create).toHaveBeenCalledWith({
+    model: 'model-vision',
+    messages: [
+      { role: 'system', content: 'instructions' },
+      { role: 'user', content: [
+        { type: 'text', text: 'prompt1' },
+        { type: 'image_url', image_url: { url: 'data:image/png;base64,image' } },
+      ]}
+    ]
+  }, {})
+})
+
 test('Cannot switch to vision if not models provided', async () => {
   const openai = new OpenAI(config)
   const messages = [

--- a/tests/unit/engine_openai_responses.test.ts
+++ b/tests/unit/engine_openai_responses.test.ts
@@ -2,11 +2,13 @@ import { LlmChunk, LlmChunkContent } from '../../src/types/llm'
 import { vi, beforeEach, expect, test, Mock } from 'vitest'
 import { Plugin2, PluginPartialPreparation } from '../mocks/plugins'
 import Message from '../../src/models/message'
+import Attachment from '../../src/models/attachment'
 import OpenAI from '../../src/providers/openai'
 import * as _openai from 'openai'
 import { EngineCreateOpts } from '../../src/types/index'
 import { Plugin } from '../../src/plugin'
 import { PluginExecutionContext, PluginParameter } from '../../src/types/plugin'
+import { z } from 'zod'
 
 Plugin2.prototype.execute = vi.fn((): Promise<string> => Promise.resolve('result2'))
 
@@ -290,6 +292,115 @@ test('OpenAI Responses API completion without tools', async () => {
   })
 })
 
+test('OpenAI Responses API forwards generation and request options', async () => {
+  const openai = new OpenAI(config)
+  const controller = new AbortController()
+
+  await openai.complete(openai.buildModel('gpt-4'), [
+    new Message('user', 'prompt'),
+  ], {
+    useResponsesApi: true,
+    tools: false,
+    maxTokens: 123,
+    temperature: 0,
+    top_p: 0.8,
+    serviceTier: 'priority',
+    structuredOutput: {
+      name: 'answer',
+      structure: z.object({ answer: z.string() }),
+    },
+    customOpts: { store: false },
+    timeout: 5000,
+    abortSignal: controller.signal,
+  })
+
+  expect(_openai.default.prototype.responses.create).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: 'gpt-4',
+      max_output_tokens: 123,
+      temperature: 0,
+      top_p: 0.8,
+      service_tier: 'priority',
+      store: false,
+      text: {
+        format: expect.objectContaining({
+          type: 'json_schema',
+          name: 'answer',
+          strict: true,
+        }),
+      },
+    }),
+    { timeout: 5000, signal: controller.signal },
+  )
+})
+
+test('OpenAI Responses API rejects failed non-streaming responses', async () => {
+  ;(_openai.default.prototype.responses.create as Mock).mockResolvedValueOnce({
+    id: 'resp_failed',
+    status: 'failed',
+    error: { code: 'server_error', message: 'generation failed' },
+    incomplete_details: null,
+    output: [],
+  })
+
+  const openai = new OpenAI(config)
+  await expect(openai.complete(openai.buildModel('gpt-4'), [
+    new Message('user', 'prompt'),
+  ], { useResponsesApi: true, tools: false })).rejects.toThrow(
+    'Responses API failed (server_error): generation failed',
+  )
+})
+
+test('OpenAI Responses API streaming uses the vision fallback model', async () => {
+  const openai = new OpenAI(config)
+  const message = new Message('user', 'describe this')
+  message.attach(new Attachment('image', 'image/png'))
+
+  await openai.stream(openai.buildModel('model-no-tool'), [message], {
+    useResponsesApi: true,
+    tools: false,
+    visionFallbackModel: openai.buildModel('model-vision'),
+  })
+
+  expect(_openai.default.prototype.responses.create).toHaveBeenCalledWith({
+    model: 'model-vision',
+    input: [{
+      type: 'message',
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'describe this' },
+        { type: 'input_image', detail: 'auto', image_url: 'data:image/png;base64,image' },
+      ],
+    }],
+    stream: true,
+  })
+})
+
+test('OpenAI Responses API surfaces streaming errors', async () => {
+  ;(_openai.default.prototype.responses.create as Mock).mockResolvedValueOnce({
+    async * [Symbol.asyncIterator]() {
+      yield {
+        type: 'error',
+        code: 'server_error',
+        message: 'stream failed',
+        param: null,
+        sequence_number: 1,
+      }
+    },
+  })
+
+  const openai = new OpenAI(config)
+  const consume = async () => {
+    for await (const chunk of openai.generate(openai.buildModel('gpt-4'), [
+      new Message('user', 'prompt'),
+    ], { useResponsesApi: true, tools: false })) {
+      void chunk
+    }
+  }
+
+  await expect(consume()).rejects.toThrow('Responses API error (server_error): stream failed')
+})
+
 test('OpenAI internal web search enables Responses API from config', async () => {
   callCount = 1
   const openai = new OpenAI({
@@ -403,6 +514,37 @@ test('OpenAI Responses API responseId continuation does not replay prior tool ca
     previous_response_id: 'resp_previous',
     input: 'what did you create?',
     stream: false,
+  })
+})
+
+test('OpenAI continueResponse returns text and response metadata', async () => {
+  callCount = 1
+  const openai = new OpenAI(config)
+
+  const response = await openai.continueResponse(
+    openai.buildModel('gpt-4'),
+    'resp_previous',
+    'continue',
+    { tools: false, usage: true },
+  )
+
+  expect(_openai.default.prototype.responses.create).toHaveBeenCalledWith({
+    model: 'gpt-4',
+    previous_response_id: 'resp_previous',
+    input: [{ type: 'message', role: 'user', content: 'continue' }],
+    stream: false,
+  })
+  expect(response).toStrictEqual({
+    type: 'text',
+    content: 'response text',
+    toolCalls: [],
+    openAIResponseId: 'resp_123',
+    usage: {
+      prompt_tokens: 10,
+      completion_tokens: 20,
+      prompt_tokens_details: { cached_tokens: 0, audio_tokens: 0 },
+      completion_tokens_details: { reasoning_tokens: 0, audio_tokens: 0 },
+    },
   })
 })
 


### PR DESCRIPTION
### Motivation

- Ensure consistent model selection and vision fallback behavior across `complete` and streaming code paths. 
- Properly forward request-level options (timeout and `abortSignal`) to OpenAI Responses calls and surface streaming errors. 
- Map existing completion/options surface to the Responses API wire format (including structured output) and validate response success.

### Description

- Call `this.selectModel(...)` earlier in `complete` and `stream` so vision fallback is applied before choosing an API. 
- Forward request options by including `abortSignal`/`signal` and `timeout` via `getRequestOptions` and using a new `createResponse` wrapper to call `this.client.responses.create` with those options. 
- Add `getResponsesCompletionOpts` to convert `LlmCompletionOpts` into `ResponseCreateParams` (including structured output using `zodTextFormat`, `max_output_tokens`, `temperature`, `top_p`, `reasoning` and `service_tier`). 
- Add `assertResponseSucceeded` to fail fast on `failed`/`incomplete` Responses results and `getResponsesText` to normalize text extraction from `response.output` and `response.output_text`. 
- Surface Responses streaming `error` events as thrown errors and handle `response.failed`/`response.incomplete` events via `assertResponseSucceeded`, and yield reasoning deltas for `response.reasoning_text.delta`/`response.reasoning_summary_text.delta`. 
- Use `getResponsesCompletionOpts` for follow-up Responses requests and for building initial Responses requests, and centralize attaching tools via `attachResponsesTools`. 
- Fix usage accumulation to tolerate absent nested fields by using optional chaining/fallbacks. 
- Use `selectModel` in `complete` so non-streaming completions also honor vision fallback. 
- Add/adjust unit tests covering vision fallback for `complete`, Responses API option forwarding (`timeout`/`signal` and structured output), streaming error propagation, `continueResponse` behavior, and other Responses API scenarios.

### Testing

- Ran unit tests in `tests/unit/engine.test.ts` and `tests/unit/engine_openai_responses.test.ts` which include new tests for vision fallback on `complete`, Responses option forwarding, streaming errors, and `continueResponse`; all tests passed. 
- Existing Responses API and streaming-related tests were updated and executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6aa6ef34f88327aabd15d6d6371c2a)